### PR TITLE
filterの掛け方について

### DIFF
--- a/main.js
+++ b/main.js
@@ -81,10 +81,15 @@ const createDltBtn = (_index) => {
         y.removeChild(x);
 
         //arr配列を削除ボタンで削除したものが反映されたary配列にする
-        let ary = arr.filter(function(value, index, array) {
+        let ary = arr.filter(function(value,index,array) {
            return index !== _index-1;
         });
+        arr = ary;
         console.log(ary);
+        console.log(arr);
+        console.log(index);
+        console.log(_index);
+
 
         //ary配列を表示させるupdateDisplay関数
         const updateDisplay = () => {
@@ -123,7 +128,9 @@ const createDltBtn = (_index) => {
 
         //indexをデクリメントする
         index--;
-        
+        console.log(index);
+        _index--;
+        console.log(_index);
 
     });
     


### PR DESCRIPTION
何度も同じようなことを聞いて申し訳ありません。
一つ目の質問なのですが、前に別のスレッドで投稿したように意図しない動作があります。具体的な内容としては、例えば、「タスクを４つ追加した後に２のタスクを削除した後に４を削除した場合に配列の要素が上手く減らない」というようなことです。一般化して説明することが難しく申し訳ありません。このような動作になってしまう原因がわかりません。
二つ目の質問としては、原因を考えていた時に色々console.logで見ていたのですが、そもそもなぜ今のfilterの条件である程度は動くのかよくわからなくなってしまいました。最初に書いた時には、押下したボタンのindexと_indexが一致しないものを拾って配列に格納できれば上手くいくのではと軽く考え、実際にそれなりに動いたので深く考えなかったのですが、今回色々考えてみて、indexや_indexをconsole.logで見てみると、indexと_indexは値が全然異なっており、filterの条件をindex !== _indexにしたのであれば、何もfilterがかからない状態になるような気がしたのですが、現実は一応配列に変化はおきており、何が起きているのかよく分からなくなってしまいました。
そもそもindex !== _indexという条件が意味なすことはなんであるのか迷走してしまいました。自分で書いておきながらこんなことを聞くのは愚かだとおもうのですが、よろしくお願いします。